### PR TITLE
make variant prop optional

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@web3icons/core": "3.0.1",
-    "@web3icons/react": "3.0.1",
+    "@web3icons/react": "3.1.0",
     "@types/node": "20.11.25",
     "@types/react": "18.2.64",
     "@types/react-dom": "18.2.21",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @web3icons/react
 
+## 3.1.0
+
+### Minor Changes
+
+- `variant` prop is now optional and defaults to `mono` when icon has supports both variants.
+
 ## 3.0.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,7 +11,7 @@
     "crypto logos",
     "coin icons"
   ],
-  "version": "3.0.1",
+  "version": "3.1.0",
   "private": false,
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -5,7 +5,7 @@ export interface BaseIconProps extends SVGProps<SVGSVGElement> {
 }
 
 export interface IconComponentProps extends SVGProps<SVGSVGElement> {
-  variant: 'mono' | 'branded'
+  variant?: 'mono' | 'branded'
   size?: number | string
   color?: string
   className?: string


### PR DESCRIPTION
The underlying logic was supporting to make the variant prop an optional one, this works because: 

if any icon has both variants (`branded` and `mono`) the component scaffold includes an initial value `variant = mono` [here](https://github.com/0xa3k5/web3icons/blob/c659723ab321ef74348dede50b429317e788e850/packages/utils/src/scaffolds/component.scaffold.ts#L6), and if the component is missing any of the variants, the JSX doesn't include that during the component generation, effectively rendering the variant prop useless.

For example: 

```jsx
<>
 <div className="flex gap-2 items-center flex-col text-xs">
  <TokenIcon symbol='SHIB' size={64} />
  {`<TokenIcon symbol='SHIB' size={64} />`}
 </div>
 <div className="flex gap-2 items-center flex-col text-xs">
  <TokenSHIB size={64} />
  {`<TokenSHIB size={64} />`}
 </div>
 <div className="flex gap-2 items-center flex-col text-xs">
  <TokenSHIB size={64} variant='mono' />
  {`<TokenSHIB size={64} variant='mono' />`}
 </div>
</>
```
would render all of the `SHIB` icons as `branded` even when the `variant="mono"` is passed because the `TokenSHIB` only comes with the `branded` variant.
![example](https://media.cleanshot.cloud/media/26546/3wVUNkacNqnd3B26JBZA498M2eIkebkUCZnH4FWx.jpeg?Expires=1722965705&Signature=NqteAyYB4XfZnPQb2DSoh9FH6CdjiA6ZxVv-rkb1zW23tP1aimLSp0mytVLTzOLlux4AdGCCzl9tzAqnosyn7LGq7xuQroEasxG7NWUsS3s1A5Ob5a6THHzzZAQwNXY2zgUOQUqAMkW57l3~5tJc0xRmul36plcGgzhGGu41qLRz7j2yUGfJ77O6Z09R1zecJH44yyhGN29oDW5zAjbSg1TbDAbcyKAkFsCKy8aSeEsp1KAVukNKEbKTxF1al7PqbJ9tRHjNRoOMP4mSNg7yOlEtPNHGj7px8vZRSuz-ve~I91RKNeeJ8HxmNUUoyBkE5re7cCUxNHU4Ch9m6J57hg__&Key-Pair-Id=K269JMAT9ZF4GZ)


and when any icon has both variants, both `TokenIcon` component and the individual icon component would default to `variant="mono"`

```jsx
<>
 <div className="flex gap-2 items-center flex-col text-xs">
  <TokenIcon symbol='ETH' size={64} />
  {`<TokenIcon symbol='ETH' size={64} />`}
 </div>
 <div className="flex gap-2 items-center flex-col text-xs">
  <TokenETH size={64} />
  {`<TokenETH size={64} />`}
 </div>
 <div className="flex gap-2 items-center flex-col text-xs">
  <TokenETH size={64} variant='mono' />
  {`<TokenETH size={64} variant='mono' />`}
 </div>
 <div className="flex gap-2 items-center flex-col text-xs">
  <TokenETH size={64} variant='branded' />
  {`<TokenETH size={64} variant='branded' />`}
 </div>
</>
```
![example](https://media.cleanshot.cloud/media/26546/nem3yrtkXHshh6cKpRZ1SWMr32eBm34JwWvonzns.jpeg?Expires=1722965890&Signature=IFM1xy0eFSwR7gn8iuCT6g823D-4yQ44j8-07go4F~OXmk5Q4cSCZqc9wC4fEj4XYh~QCRDS-mjCNXWv~t6o8XQ7KLZNeu17MQx2fAgXkQUskDMB3LJ~Q5FRIypYobRUCJt5wvKBsxXdfpC1ff~v5UqJkfuoQNmohVCP4TUk6rxUNSfweoZ4qC9jYCL8vp-Blw1nIDdRPWUnlHb84dpSWC1tCChJ-QJH1uCsqfwdnDYwARre9ZP1XuTjyzC22jYTZwA0a9zlTC8bN6RZIsW8xIejFSuL~aohx4qVAVVtMuiKajn0ON7Tjd~IZ2njtUUYxuG~dj~21fgxPoJVBmkBrg__&Key-Pair-Id=K269JMAT9ZF4GZ)


fixes #15 
